### PR TITLE
Fix: Use Helper only when needed

### DIFF
--- a/test/Unit/Exception/InvalidRangeTest.php
+++ b/test/Unit/Exception/InvalidRangeTest.php
@@ -15,7 +15,6 @@ namespace Ergebnis\License\Test\Unit\Exception;
 
 use Ergebnis\License\Exception\InvalidRange;
 use Ergebnis\License\Year;
-use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
 
 /**
@@ -27,8 +26,6 @@ use PHPUnit\Framework;
  */
 final class InvalidRangeTest extends Framework\TestCase
 {
-    use Helper;
-
     public function testStartYearGreaterThanEndYearReturnsInvalidRange(): void
     {
         $start = Year::fromString('2020');

--- a/test/Unit/RangeTest.php
+++ b/test/Unit/RangeTest.php
@@ -16,7 +16,6 @@ namespace Ergebnis\License\Test\Unit;
 use Ergebnis\License\Exception;
 use Ergebnis\License\Range;
 use Ergebnis\License\Year;
-use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
 
 /**
@@ -30,8 +29,6 @@ use PHPUnit\Framework;
  */
 final class RangeTest extends Framework\TestCase
 {
-    use Helper;
-
     public function testIncludingRequiresStartYearToBeEqualOrLessThanEndYear(): void
     {
         $start = Year::fromString('2020');


### PR DESCRIPTION
This PR

* [x] uses the `Helper` only when needed