### PR TITLE
Fix: Rename test method

### DIFF
--- a/test/Unit/TemplateTest.php
+++ b/test/Unit/TemplateTest.php
@@ -29,7 +29,7 @@ final class TemplateTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testCreateReturnsTemplate(): void
+    public function testFromStringReturnsTemplate(): void
     {
         $faker = self::faker();
 


### PR DESCRIPTION
This PR

* [x] renames a test method

Follows #20.