### PR TITLE
Fix: Use actual test in expectations

### DIFF
--- a/test/Unit/Type/MITTest.php
+++ b/test/Unit/Type/MITTest.php
@@ -15,7 +15,6 @@ namespace Ergebnis\License\Test\Unit\Type;
 
 use Ergebnis\License\Holder;
 use Ergebnis\License\Range;
-use Ergebnis\License\Template;
 use Ergebnis\License\Type\MIT;
 use Ergebnis\License\Url;
 use Ergebnis\License\Year;
@@ -58,10 +57,14 @@ final class MITTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $name = \sprintf(
-            '%s/%s.txt',
-            self::workspaceDirectory(),
+        $baseName = \sprintf(
+            '%s.txt',
             $faker->slug
+        );
+        $name = \sprintf(
+            '%s/%s',
+            self::workspaceDirectory(),
+            $baseName
         );
         $range = Range::since(
             Year::fromString($faker->year),
@@ -77,12 +80,15 @@ final class MITTest extends Framework\TestCase
             $url
         );
 
-        $expected = Template::fromFile(__DIR__ . '/../../../resource/header.txt')->toString([
-            '<file>' => \basename($name),
-            '<holder>' => $holder->toString(),
-            '<range>' => $range->toString(),
-            '<url>' => $url->toString(),
-        ]);
+        $expected = <<<TXT
+Copyright (c) {$range->toString()} {$holder->toString()}
+
+For the full copyright and license information, please view
+the {$baseName} file that was distributed with this source code.
+
+@see {$url->toString()}
+
+TXT;
 
         self::assertSame($expected, $license->header());
     }
@@ -92,9 +98,13 @@ final class MITTest extends Framework\TestCase
         $faker = self::faker();
 
         $name = \sprintf(
-            '%s/%s.txt',
-            self::workspaceDirectory(),
+            '%s.txt',
             $faker->slug
+        );
+        $baseName = \sprintf(
+            '%s/%s',
+            self::workspaceDirectory(),
+            $name
         );
         $range = Range::since(
             Year::fromString($faker->year),
@@ -104,18 +114,21 @@ final class MITTest extends Framework\TestCase
         $url = Url::fromString($faker->url);
 
         $license = MIT::text(
-            $name,
+            $baseName,
             $range,
             $holder,
             $url
         );
 
-        $expected = Template::fromFile(__DIR__ . '/../../../resource/header.txt')->toString([
-            '<file>' => \basename($name),
-            '<holder>' => $holder->toString(),
-            '<range>' => $range->toString(),
-            '<url>' => $url->toString(),
-        ]);
+        $expected = <<<TXT
+Copyright (c) {$range->toString()} {$holder->toString()}
+
+For the full copyright and license information, please view
+the {$name} file that was distributed with this source code.
+
+@see {$url->toString()}
+
+TXT;
 
         self::assertSame($expected, $license->header());
     }
@@ -147,10 +160,25 @@ final class MITTest extends Framework\TestCase
 
         self::assertFileExists($name);
 
-        $expected = Template::fromFile(__DIR__ . '/../../../resource/license/MIT.md')->toString([
-            '<holder>' => $holder->toString(),
-            '<range>' => $range->toString(),
-        ]);
+        $expected = <<<TXT
+# The MIT License (MIT)
+
+Copyright (c) {$range->toString()} {$holder->toString()}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the _Software_), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED **AS IS**, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+TXT;
 
         self::assertSame($expected, \file_get_contents($name));
     }
@@ -182,10 +210,25 @@ final class MITTest extends Framework\TestCase
 
         self::assertFileExists($name);
 
-        $expected = Template::fromFile(__DIR__ . '/../../../resource/license/MIT.txt')->toString([
-            '<holder>' => $holder->toString(),
-            '<range>' => $range->toString(),
-        ]);
+        $expected = <<<TXT
+The MIT License (MIT)
+
+Copyright (c) {$range->toString()} {$holder->toString()}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+TXT;
 
         self::assertSame($expected, \file_get_contents($name));
     }


### PR DESCRIPTION
This PR

* [x] uses the actual text in expectations

Follows #38.