### PR TITLE
Fix: Drop support for PHP 7.1

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,13 +15,10 @@ branches:
       required_status_checks:
         contexts:
           - "Code Coverage (7.4, locked)"
-          - "Coding Standards (7.1, locked)"
+          - "Coding Standards (7.2, locked)"
           - "Dependency Analysis (7.4, locked)"
           - "Mutation Tests (7.4, locked)"
           - "Static Code Analysis (7.4, locked)"
-          - "Tests (7.1, highest)"
-          - "Tests (7.1, locked)"
-          - "Tests (7.1, lowest)"
           - "Tests (7.2, highest)"
           - "Tests (7.2, locked)"
           - "Tests (7.2, lowest)"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"
@@ -195,7 +195,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.0.0...main`][1.0.0...main].
+For a full diff see [`1.0.1...main`][1.0.1...main].
+
+## [`1.0.1`][1.0.1]
+
+For a full diff see [`1.0.0...1.0.1`][1.0.0...1.0.1].
+
+## Changed
+
+* Dropped support for PHP 7.1 ([#171]), by [@localheinz]
 
 ## [`1.0.0`][1.0.0]
 
@@ -29,10 +37,12 @@ For a full diff see [`675601b...0.1.0`][675601b...0.1.0].
 
 [0.1.0]: https://github.com/ergebnis/license/releases/tag/0.1.0
 [1.0.0]: https://github.com/ergebnis/license/releases/tag/1.0.0
+[1.0.1]: https://github.com/ergebnis/license/releases/tag/1.0.1
 
 [675601b...0.1.0]: https://github.com/ergebnis/license/compare/675601b...0.1.0
 [0.1.0...1.0.0]: https://github.com/ergebnis/license/compare/0.1.0...1.0.0
-[1.0.0...main]: https://github.com/ergebnis/license/compare/1.0.0...main
+[1.0.0...1.0.1]: https://github.com/ergebnis/license/compare/1.0.0...1.0.1
+[1.0.1...main]: https://github.com/ergebnis/license/compare/1.0.1...main
 
 [#7]: https://github.com/ergebnis/license/pull/7
 [#10]: https://github.com/ergebnis/license/pull/10
@@ -42,5 +52,6 @@ For a full diff see [`675601b...0.1.0`][675601b...0.1.0].
 [#33]: https://github.com/ergebnis/license/pull/33
 [#34]: https://github.com/ergebnis/license/pull/34
 [#38]: https://github.com/ergebnis/license/pull/38
+[#171]: https://github.com/ergebnis/license/pull/171
 
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.2",
     "ext-filter": "*"
   },
   "require-dev": {
@@ -36,7 +36,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.1.33"
+      "php": "7.2.33"
     },
     "preferred-install": "dist",
     "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15ae6a2139bee0aa021395ae34feeefc",
+    "content-hash": "fd09125f5cf1aa45f0cc8a94e583ac02",
     "packages": [],
     "packages-dev": [
         {
@@ -5135,12 +5135,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1",
+        "php": "^7.2",
         "ext-filter": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.33"
+        "php": "7.2.33"
     },
     "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
This PR

* [x] drops support for PHP 7.1

Related to https://github.com/ergebnis/composer-normalize/issues/529.