### PR TITLE
Fix: Use methods instead of deprecated magic properties

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,10 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.6.1@e93e532e4eaad6d68c4d7b606853800eaceccc72">
+<files psalm-version="4.17.0@6f4707aa41c9174353a6434bba3fc8840f981d9c">
   <file src="src/Template.php">
     <DocblockTypeContradiction occurrences="2">
       <code>return !\is_string($key);</code>
       <code>return !\is_string($value);</code>
     </DocblockTypeContradiction>
+  </file>
+  <file src="test/Unit/Exception/InvalidFileTest.php">
+    <MixedArgument occurrences="2">
+      <code>$faker-&gt;fileExtension()</code>
+      <code>$faker-&gt;fileExtension()</code>
+    </MixedArgument>
+  </file>
+  <file src="test/Unit/FileTest.php">
+    <MixedArgument occurrences="3">
+      <code>$faker-&gt;timezone()</code>
+      <code>$faker-&gt;timezone()</code>
+      <code>$faker-&gt;timezone()</code>
+    </MixedArgument>
+    <UndefinedMagicMethod occurrences="3">
+      <code>timezone</code>
+      <code>timezone</code>
+      <code>timezone</code>
+    </UndefinedMagicMethod>
+  </file>
+  <file src="test/Unit/HeaderTest.php">
+    <MixedArgument occurrences="1">
+      <code>$faker-&gt;timezone()</code>
+    </MixedArgument>
+    <UndefinedMagicMethod occurrences="1">
+      <code>timezone</code>
+    </UndefinedMagicMethod>
   </file>
   <file src="test/Unit/HolderTest.php">
     <MixedArgument occurrences="1">
@@ -35,6 +61,28 @@
       <code>\Generator</code>
       <code>\Generator</code>
     </MixedInferredReturnType>
+  </file>
+  <file src="test/Unit/Type/MITTest.php">
+    <MixedArgument occurrences="8">
+      <code>$faker-&gt;timezone()</code>
+      <code>$faker-&gt;timezone()</code>
+      <code>$faker-&gt;timezone()</code>
+      <code>$faker-&gt;timezone()</code>
+      <code>$faker-&gt;url()</code>
+      <code>$faker-&gt;url()</code>
+      <code>$faker-&gt;url()</code>
+      <code>$faker-&gt;url()</code>
+    </MixedArgument>
+    <UndefinedMagicMethod occurrences="8">
+      <code>timezone</code>
+      <code>timezone</code>
+      <code>timezone</code>
+      <code>timezone</code>
+      <code>url</code>
+      <code>url</code>
+      <code>url</code>
+      <code>url</code>
+    </UndefinedMagicMethod>
   </file>
   <file src="test/Unit/UrlTest.php">
     <MixedArgument occurrences="1">

--- a/test/Unit/Exception/InvalidFileTest.php
+++ b/test/Unit/Exception/InvalidFileTest.php
@@ -41,8 +41,8 @@ final class InvalidFileTest extends Framework\TestCase
 
         $name = \sprintf(
             '%s.%s',
-            $faker->slug,
-            $faker->fileExtension
+            $faker->slug(),
+            $faker->fileExtension()
         );
 
         $exception = InvalidFile::doesNotExist($name);
@@ -61,8 +61,8 @@ final class InvalidFileTest extends Framework\TestCase
 
         $name = \sprintf(
             '%s.%s',
-            $faker->slug,
-            $faker->fileExtension
+            $faker->slug(),
+            $faker->fileExtension()
         );
 
         $exception = InvalidFile::canNotBeRead($name);

--- a/test/Unit/Exception/InvalidUrlTest.php
+++ b/test/Unit/Exception/InvalidUrlTest.php
@@ -28,7 +28,7 @@ final class InvalidUrlTest extends Framework\TestCase
 
     public function testFromValueReturnsInvalidUrl(): void
     {
-        $value = self::faker()->sentence;
+        $value = self::faker()->sentence();
 
         $exception = InvalidUrl::fromValue($value);
 

--- a/test/Unit/Exception/InvalidYearTest.php
+++ b/test/Unit/Exception/InvalidYearTest.php
@@ -28,7 +28,7 @@ final class InvalidYearTest extends Framework\TestCase
 
     public function testFromValueReturnsInvalidYear(): void
     {
-        $value = self::faker()->sentence;
+        $value = self::faker()->sentence();
 
         $exception = InvalidYear::fromValue($value);
 

--- a/test/Unit/FileTest.php
+++ b/test/Unit/FileTest.php
@@ -61,10 +61,10 @@ final class FileTest extends Framework\TestCase
 
         $template = Template::fromFile(__DIR__ . '/../../resource/license/MIT.txt');
         $range = Range::since(
-            Year::fromString($faker->year),
-            new \DateTimeZone($faker->timezone)
+            Year::fromString($faker->year()),
+            new \DateTimeZone($faker->timezone())
         );
-        $holder = Holder::fromString($faker->name);
+        $holder = Holder::fromString($faker->name());
 
         $this->expectException(Exception\InvalidFile::class);
 
@@ -83,14 +83,14 @@ final class FileTest extends Framework\TestCase
         $name = \sprintf(
             '%s/%s.txt',
             __DIR__,
-            $faker->slug
+            $faker->slug()
         );
         $template = Template::fromFile(__DIR__ . '/../../resource/license/MIT.txt');
         $range = Range::since(
-            Year::fromString($faker->year),
-            new \DateTimeZone($faker->timezone)
+            Year::fromString($faker->year()),
+            new \DateTimeZone($faker->timezone())
         );
-        $holder = Holder::fromString($faker->name);
+        $holder = Holder::fromString($faker->name());
 
         $file = File::create(
             $name,
@@ -109,14 +109,14 @@ final class FileTest extends Framework\TestCase
         $name = \sprintf(
             '%s/%s.txt',
             self::workspaceDirectory(),
-            $faker->slug
+            $faker->slug()
         );
         $template = Template::fromFile(__DIR__ . '/../../resource/license/MIT.txt');
         $range = Range::since(
-            Year::fromString($faker->year),
-            new \DateTimeZone($faker->timezone)
+            Year::fromString($faker->year()),
+            new \DateTimeZone($faker->timezone())
         );
-        $holder = Holder::fromString($faker->name);
+        $holder = Holder::fromString($faker->name());
 
         $file = File::create(
             $name,

--- a/test/Unit/HeaderTest.php
+++ b/test/Unit/HeaderTest.php
@@ -45,10 +45,10 @@ final class HeaderTest extends Framework\TestCase
 
         $template = Template::fromFile(__DIR__ . '/../../resource/header.txt');
         $range = Range::since(
-            Year::fromString($faker->year),
-            new \DateTimeZone($faker->timezone)
+            Year::fromString($faker->year()),
+            new \DateTimeZone($faker->timezone())
         );
-        $holder = Holder::fromString($faker->name);
+        $holder = Holder::fromString($faker->name());
         $file = File::create(
             \sprintf(
                 '%s/%s.txt',

--- a/test/Unit/HolderTest.php
+++ b/test/Unit/HolderTest.php
@@ -61,7 +61,7 @@ final class HolderTest extends Framework\TestCase
             foreach ($newLineCharacters as $middle) {
                 foreach ($newLineCharacters as $end) {
                     /** @var string[] $words */
-                    $words = self::faker()->words;
+                    $words = self::faker()->words();
 
                     yield [
                         \sprintf(

--- a/test/Unit/TemplateTest.php
+++ b/test/Unit/TemplateTest.php
@@ -35,7 +35,7 @@ final class TemplateTest extends Framework\TestCase
         $faker = self::faker();
 
         $when = $faker->dateTime->format('Y');
-        $who = $faker->name;
+        $who = $faker->name();
 
         $template = Template::fromString(
             <<<'EOF'
@@ -92,7 +92,7 @@ EOF;
         $faker = self::faker();
 
         $when = $faker->dateTime->format('Y');
-        $who = $faker->name;
+        $who = $faker->name();
 
         $template = Template::fromFile(__DIR__ . '/../Fixture/Template/template.txt');
 
@@ -158,7 +158,7 @@ EOF;
         $faker = self::faker();
 
         $values = [
-            'array' => $faker->words,
+            'array' => $faker->words(),
             'boolean-false' => false,
             'boolean-true' => true,
             'float' => $faker->randomFloat(2, 1),

--- a/test/Unit/Type/MITTest.php
+++ b/test/Unit/Type/MITTest.php
@@ -59,7 +59,7 @@ final class MITTest extends Framework\TestCase
 
         $baseName = \sprintf(
             '%s.txt',
-            $faker->slug
+            $faker->slug()
         );
         $name = \sprintf(
             '%s/%s',
@@ -67,11 +67,11 @@ final class MITTest extends Framework\TestCase
             $baseName
         );
         $range = Range::since(
-            Year::fromString($faker->year),
-            new \DateTimeZone($faker->timezone)
+            Year::fromString($faker->year()),
+            new \DateTimeZone($faker->timezone())
         );
-        $holder = Holder::fromString($faker->name);
-        $url = Url::fromString($faker->url);
+        $holder = Holder::fromString($faker->name());
+        $url = Url::fromString($faker->url());
 
         $license = MIT::markdown(
             $name,
@@ -99,7 +99,7 @@ TXT;
 
         $name = \sprintf(
             '%s.txt',
-            $faker->slug
+            $faker->slug()
         );
         $baseName = \sprintf(
             '%s/%s',
@@ -107,11 +107,11 @@ TXT;
             $name
         );
         $range = Range::since(
-            Year::fromString($faker->year),
-            new \DateTimeZone($faker->timezone)
+            Year::fromString($faker->year()),
+            new \DateTimeZone($faker->timezone())
         );
-        $holder = Holder::fromString($faker->name);
-        $url = Url::fromString($faker->url);
+        $holder = Holder::fromString($faker->name());
+        $url = Url::fromString($faker->url());
 
         $license = MIT::text(
             $baseName,
@@ -140,14 +140,14 @@ TXT;
         $name = \sprintf(
             '%s/%s.md',
             self::workspaceDirectory(),
-            $faker->slug
+            $faker->slug()
         );
         $range = Range::since(
-            Year::fromString($faker->year),
-            new \DateTimeZone($faker->timezone)
+            Year::fromString($faker->year()),
+            new \DateTimeZone($faker->timezone())
         );
-        $holder = Holder::fromString($faker->name);
-        $url = Url::fromString($faker->url);
+        $holder = Holder::fromString($faker->name());
+        $url = Url::fromString($faker->url());
 
         $license = MIT::markdown(
             $name,
@@ -190,14 +190,14 @@ TXT;
         $name = \sprintf(
             '%s/%s.txt',
             self::workspaceDirectory(),
-            $faker->slug
+            $faker->slug()
         );
         $range = Range::since(
-            Year::fromString($faker->year),
-            new \DateTimeZone($faker->timezone)
+            Year::fromString($faker->year()),
+            new \DateTimeZone($faker->timezone())
         );
-        $holder = Holder::fromString($faker->name);
-        $url = Url::fromString($faker->url);
+        $holder = Holder::fromString($faker->name());
+        $url = Url::fromString($faker->url());
 
         $license = MIT::text(
             $name,

--- a/test/Unit/UrlTest.php
+++ b/test/Unit/UrlTest.php
@@ -42,7 +42,7 @@ final class UrlTest extends Framework\TestCase
     public function provideInvalidValue(): \Generator
     {
         $values = [
-            'string-arbitrary' => self::faker()->sentence,
+            'string-arbitrary' => self::faker()->sentence(),
             'string-blank' => '  ',
             'string-empty' => '',
         ];

--- a/test/Unit/YearTest.php
+++ b/test/Unit/YearTest.php
@@ -44,13 +44,13 @@ final class YearTest extends Framework\TestCase
         $faker = self::faker();
 
         $values = [
-            'string-arbitrary' => $faker->sentence,
+            'string-arbitrary' => $faker->sentence(),
             'string-blank' => '  ',
             'string-containing-year' => \sprintf(
                 '%s %s %s',
-                $faker->word,
-                $faker->year,
-                $faker->word
+                $faker->word(),
+                $faker->year(),
+                $faker->word()
             ),
             'string-empty' => '',
         ];
@@ -91,15 +91,15 @@ final class YearTest extends Framework\TestCase
     {
         $faker = self::faker()->unique();
 
-        $one = Year::fromString($faker->year);
-        $two = Year::fromString($faker->year);
+        $one = Year::fromString($faker->year());
+        $two = Year::fromString($faker->year());
 
         self::assertFalse($one->equals($two));
     }
 
     public function testEqualsReturnsTrueWhenValueIsSame(): void
     {
-        $value = self::faker()->year;
+        $value = self::faker()->year();
 
         $one = Year::fromString($value);
         $two = Year::fromString($value);
@@ -109,7 +109,7 @@ final class YearTest extends Framework\TestCase
 
     public function testGreaterThanReturnsFalseWhenValueIsEqual(): void
     {
-        $value = self::faker()->year;
+        $value = self::faker()->year();
 
         $one = Year::fromString($value);
         $two = Year::fromString($value);


### PR DESCRIPTION
This pull request

- [x] uses methods instead of deprecated magic properties