### PR TITLE
Fix: Rename named constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.2.0...main`][1.2.0...main].
 
+## Changed
+
+- Renamed `Header::create()` to `Header::createWithReferenceToLicenseFile()` ([#533]), by [@localheinz]
+
 ## [`1.2.0`][1.2.0]
 
 For a full diff see [`1.1.0...1.2.0`][1.1.0...1.2.0].
@@ -77,5 +81,6 @@ For a full diff see [`675601b...0.1.0`][675601b...0.1.0].
 [#177]: https://github.com/ergebnis/license/pull/177
 [#416]: https://github.com/ergebnis/license/pull/416
 [#422]: https://github.com/ergebnis/license/pull/422
+[#533]: https://github.com/ergebnis/license/pull/533
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Header.php
+++ b/src/Header.php
@@ -35,7 +35,7 @@ final class Header
         $this->url = $url;
     }
 
-    public static function create(
+    public static function createWithReferenceToLicenseFile(
         Template $template,
         Period $period,
         Holder $holder,

--- a/src/Type/MIT.php
+++ b/src/Type/MIT.php
@@ -40,7 +40,7 @@ final class MIT
             $holder,
         );
 
-        $header = Header::create(
+        $header = Header::createWithReferenceToLicenseFile(
             $headerTemplate,
             $period,
             $holder,

--- a/test/Unit/HeaderTest.php
+++ b/test/Unit/HeaderTest.php
@@ -39,7 +39,7 @@ final class HeaderTest extends Framework\TestCase
 {
     use Test\Util\Helper;
 
-    public function testToStringReturnsStringRepresentation(): void
+    public function testCreateWithReferenceToLicenseFileReturnsHeader(): void
     {
         $faker = self::faker();
 
@@ -61,7 +61,7 @@ final class HeaderTest extends Framework\TestCase
         );
         $url = Url::fromString($faker->url);
 
-        $header = Header::create(
+        $header = Header::createWithReferenceToLicenseFile(
             $template,
             $range,
             $holder,


### PR DESCRIPTION
This pull request

- [x] renames `Header::create()` to `Header::createWithReferenceToLicenseFile()`