### PR TITLE
Enhancement: Add `BSD-3-Clause` as usable license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`2.2.0...main`][2.2.0...main].
 ## Added
 
 - Added support for PHP 8.3 ([#734]), by [@localheinz]
+- Added `BSD3Clause` ([#740]), by [@oruborus]
 
 ## [`2.2.0`][2.2.0]
 
@@ -121,5 +122,7 @@ For a full diff see [`675601b...0.1.0`][675601b...0.1.0].
 [#550]: https://github.com/ergebnis/license/pull/550
 [#644]: https://github.com/ergebnis/license/pull/644
 [#734]: https://github.com/ergebnis/license/pull/734
+[#740]: https://github.com/ergebnis/license/pull/740
 
 [@localheinz]: https://github.com/localheinz
+[@oruborus]: https://github.com/oruborus

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Note that pull requests opened or commits pushed by GitHub Actions will not trig
 
 The following license types are currently available:
 
+- [`Ergebnis\License\Type\MIT`](src/Type/BSD3Clause.php)
 - [`Ergebnis\License\Type\MIT`](src/Type/MIT.php)
 - [`Ergebnis\License\Type\None`](src/Type/None.php)
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -55,6 +55,14 @@
       <code>provideReplacementsWithInvalidValues</code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="test/Unit/Type/BSD3ClauseTest.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$faker->timezone()]]></code>
+      <code><![CDATA[$faker->timezone()]]></code>
+      <code><![CDATA[$faker->timezone()]]></code>
+      <code><![CDATA[$faker->timezone()]]></code>
+    </ArgumentTypeCoercion>
+  </file>
   <file src="test/Unit/Type/MITTest.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$faker->timezone()]]></code>

--- a/resource/license/BSD3Clause.md
+++ b/resource/license/BSD3Clause.md
@@ -1,0 +1,19 @@
+# BSD 3-Clause "New" or "Revised" License
+
+Copyright (c) <range> <holder>.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials
+   provided with the distribution.
+
+   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written
+   permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS **AS IS** AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/resource/license/BSD3Clause.txt
+++ b/resource/license/BSD3Clause.txt
@@ -1,0 +1,19 @@
+BSD 3-Clause "New" or "Revised" License
+
+Copyright (c) <range> <holder>.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials
+    provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written
+    permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/Type/BSD3Clause.php
+++ b/src/Type/BSD3Clause.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020-2023 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/license
+ */
+
+namespace Ergebnis\License\Type;
+
+use Ergebnis\License\File;
+use Ergebnis\License\Header;
+use Ergebnis\License\Holder;
+use Ergebnis\License\Period;
+use Ergebnis\License\Template;
+use Ergebnis\License\Url;
+
+final class BSD3Clause
+{
+    private readonly File $file;
+    private readonly Header $header;
+
+    private function __construct(
+        string $name,
+        Template $fileTemplate,
+        Template $headerTemplate,
+        Period $period,
+        Holder $holder,
+        Url $url,
+    ) {
+        $file = File::create(
+            $name,
+            $fileTemplate,
+            $period,
+            $holder,
+        );
+
+        $header = Header::createWithReferenceToLicenseFile(
+            $headerTemplate,
+            $period,
+            $holder,
+            $file,
+            $url,
+        );
+
+        $this->file = $file;
+        $this->header = $header;
+    }
+
+    public static function markdown(
+        string $name,
+        Period $period,
+        Holder $holder,
+        Url $url,
+    ): self {
+        return new self(
+            $name,
+            Template::fromFile(__DIR__ . '/../../resource/license/BSD3Clause.md'),
+            Template::fromFile(__DIR__ . '/../../resource/header/with-reference-to-license-file.txt'),
+            $period,
+            $holder,
+            $url,
+        );
+    }
+
+    public static function text(
+        string $name,
+        Period $period,
+        Holder $holder,
+        Url $url,
+    ): self {
+        return new self(
+            $name,
+            Template::fromFile(__DIR__ . '/../../resource/license/BSD3Clause.txt'),
+            Template::fromFile(__DIR__ . '/../../resource/header/with-reference-to-license-file.txt'),
+            $period,
+            $holder,
+            $url,
+        );
+    }
+
+    public function save(): void
+    {
+        $this->file->save();
+    }
+
+    public function header(): string
+    {
+        return $this->header->toString();
+    }
+}

--- a/test/Unit/Type/BSD3ClauseTest.php
+++ b/test/Unit/Type/BSD3ClauseTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020-2023 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/license
+ */
+
+namespace Ergebnis\License\Test\Unit\Type;
+
+use Ergebnis\License\File;
+use Ergebnis\License\Header;
+use Ergebnis\License\Holder;
+use Ergebnis\License\Range;
+use Ergebnis\License\Template;
+use Ergebnis\License\Test;
+use Ergebnis\License\Type;
+use Ergebnis\License\Url;
+use Ergebnis\License\Year;
+use PHPUnit\Framework;
+use Symfony\Component\Filesystem;
+
+#[Framework\Attributes\CoversClass(Type\BSD3Clause::class)]
+#[Framework\Attributes\UsesClass(File::class)]
+#[Framework\Attributes\UsesClass(Header::class)]
+#[Framework\Attributes\UsesClass(Holder::class)]
+#[Framework\Attributes\UsesClass(Range::class)]
+#[Framework\Attributes\UsesClass(Template::class)]
+#[Framework\Attributes\UsesClass(Url::class)]
+#[Framework\Attributes\UsesClass(Year::class)]
+final class BSD3ClauseTest extends Framework\TestCase
+{
+    use Test\Util\Helper;
+
+    protected function setUp(): void
+    {
+        $filesystem = new Filesystem\Filesystem();
+
+        $filesystem->mkdir(self::temporaryDirectory());
+    }
+
+    protected function tearDown(): void
+    {
+        $filesystem = new Filesystem\Filesystem();
+
+        $filesystem->remove(self::temporaryDirectory());
+    }
+
+    public function testHeaderReturnsHeaderForMarkdownLicense(): void
+    {
+        $faker = self::faker();
+
+        $baseName = \sprintf(
+            '%s.txt',
+            $faker->slug(),
+        );
+        $name = \sprintf(
+            '%s/%s',
+            self::temporaryDirectory(),
+            $baseName,
+        );
+        $range = Range::since(
+            Year::fromString($faker->year()),
+            new \DateTimeZone($faker->timezone()),
+        );
+        $holder = Holder::fromString($faker->name());
+        $url = Url::fromString($faker->url());
+
+        $license = Type\BSD3Clause::markdown(
+            $name,
+            $range,
+            $holder,
+            $url,
+        );
+
+        $expected = <<<TXT
+Copyright (c) {$range->toString()} {$holder->toString()}
+
+For the full copyright and license information, please view
+the {$baseName} file that was distributed with this source code.
+
+@see {$url->toString()}
+
+TXT;
+
+        self::assertSame($expected, $license->header());
+    }
+
+    public function testHeaderReturnsHeaderForTextLicense(): void
+    {
+        $faker = self::faker();
+
+        $name = \sprintf(
+            '%s.txt',
+            $faker->slug(),
+        );
+        $baseName = \sprintf(
+            '%s/%s',
+            self::temporaryDirectory(),
+            $name,
+        );
+        $range = Range::since(
+            Year::fromString($faker->year()),
+            new \DateTimeZone($faker->timezone()),
+        );
+        $holder = Holder::fromString($faker->name());
+        $url = Url::fromString($faker->url());
+
+        $license = Type\BSD3Clause::text(
+            $baseName,
+            $range,
+            $holder,
+            $url,
+        );
+
+        $expected = <<<TXT
+Copyright (c) {$range->toString()} {$holder->toString()}
+
+For the full copyright and license information, please view
+the {$name} file that was distributed with this source code.
+
+@see {$url->toString()}
+
+TXT;
+
+        self::assertSame($expected, $license->header());
+    }
+
+    public function testSaveSavesMarkdownToFileForMarkdownLicense(): void
+    {
+        $faker = self::faker();
+
+        $name = \sprintf(
+            '%s/%s.md',
+            self::temporaryDirectory(),
+            $faker->slug(),
+        );
+        $range = Range::since(
+            Year::fromString($faker->year()),
+            new \DateTimeZone($faker->timezone()),
+        );
+        $holder = Holder::fromString($faker->name());
+        $url = Url::fromString($faker->url());
+
+        $license = Type\BSD3Clause::markdown(
+            $name,
+            $range,
+            $holder,
+            $url,
+        );
+
+        $license->save();
+
+        self::assertFileExists($name);
+
+        $expected = <<<TXT
+# BSD 3-Clause "New" or "Revised" License
+
+Copyright (c) {$range->toString()} {$holder->toString()}.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials
+   provided with the distribution.
+
+   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written
+   permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS **AS IS** AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+TXT;
+
+        self::assertSame($expected, \file_get_contents($name));
+    }
+
+    public function testSaveSavesTextToFileForTextLicense(): void
+    {
+        $faker = self::faker();
+
+        $name = \sprintf(
+            '%s/%s.txt',
+            self::temporaryDirectory(),
+            $faker->slug(),
+        );
+        $range = Range::since(
+            Year::fromString($faker->year()),
+            new \DateTimeZone($faker->timezone()),
+        );
+        $holder = Holder::fromString($faker->name());
+        $url = Url::fromString($faker->url());
+
+        $license = Type\BSD3Clause::text(
+            $name,
+            $range,
+            $holder,
+            $url,
+        );
+
+        $license->save();
+
+        self::assertFileExists($name);
+
+        $expected = <<<TXT
+BSD 3-Clause "New" or "Revised" License
+
+Copyright (c) {$range->toString()} {$holder->toString()}.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials
+    provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written
+    permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+TXT;
+
+        self::assertSame($expected, \file_get_contents($name));
+    }
+}


### PR DESCRIPTION
This pull request

- [x] adds a new usable license to the library: [ BSD-3-Clause - SPDX License List entry](https://spdx.org/licenses/BSD-3-Clause.html)

Replaces #731.

